### PR TITLE
Lint/format: fix E702/E231/E302/E401/F401 and style pass

### DIFF
--- a/neural_chaos_lab_max/cli.py
+++ b/neural_chaos_lab_max/cli.py
@@ -1,4 +1,6 @@
-import typer, json, numpy as np, os
+import typer
+import numpy as np
+import os
 from .systems import lorenz, rossler
 from .esn import ESN
 from .neural_ode import NeuralODEModel
@@ -6,19 +8,22 @@ from .plotting import plot_attractor
 
 app = typer.Typer(help="Neural Chaos Lab Max CLI")
 
+
 @app.command()
 def generate(system: str = "lorenz", n: int = 5000, out: str = "data/series.csv"):
     os.makedirs(os.path.dirname(out), exist_ok=True)
-    series = lorenz(n) if system=="lorenz" else rossler(n)
+    series = lorenz(n) if system == "lorenz" else rossler(n)
     np.savetxt(out, series, delimiter=",")
     typer.echo(f"Wrote {out}")
+
 
 @app.command()
 def train(data: str = "data/series.csv", epochs: int = 5, method: str = "neuralode"):
     series = np.loadtxt(data, delimiter=",", dtype=float)
-    if method=="esn":
+    if method == "esn":
         esn = ESN(n_inputs=3, n_res=500)
-        U = series[:-1]; Y = series[1:]
+        U = series[:-1]
+        Y = series[1:]
         esn.fit(U, Y)
         np.save("models/esn.npy", np.array([esn.Win, esn.W, esn.Wout], dtype=object))
         typer.echo("Saved models/esn.npy")
@@ -27,26 +32,33 @@ def train(data: str = "data/series.csv", epochs: int = 5, method: str = "neuralo
         m.fit_series(series, epochs=epochs)
         os.makedirs("models", exist_ok=True)
         import torch
+
         torch.save(m.state_dict(), "models/neuralode.pt")
         typer.echo("Saved models/neuralode.pt")
 
+
 @app.command("forecast-cmd")
-def forecast_cmd(data: str = "data/series.csv", steps: int = 200, method: str = "neuralode"):
+def forecast_cmd(
+    data: str = "data/series.csv", steps: int = 200, method: str = "neuralode"
+):
     series = np.loadtxt(data, delimiter=",", dtype=float)
-    if method=="esn":
+    if method == "esn":
         esn = ESN(n_inputs=3, n_res=500)
-        U = series[:-1]; Y = series[1:]
+        U = series[:-1]
+        Y = series[1:]
         esn.fit(U, Y)
         Yhat = esn.predict(U)
     else:
         from .neural_ode import NeuralODEModel
         import torch
+
         m = NeuralODEModel(dim=3)
         if os.path.exists("models/neuralode.pt"):
             m.load_state_dict(torch.load("models/neuralode.pt", map_location="cpu"))
         Yhat = m.forecast(series[-1], steps=steps)
     np.savetxt("reports/forecast.csv", Yhat, delimiter=",")
     typer.echo("Wrote reports/forecast.csv")
+
 
 @app.command()
 def plot(data: str = "data/series.csv", out_html: str = "reports/attractor.html"):
@@ -55,6 +67,7 @@ def plot(data: str = "data/series.csv", out_html: str = "reports/attractor.html"
     fig = plot_attractor(series, "Attractor")
     fig.write_html(out_html)
     typer.echo(f"Wrote {out_html}")
+
 
 if __name__ == "__main__":
     app()

--- a/neural_chaos_lab_max/esn.py
+++ b/neural_chaos_lab_max/esn.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 class ESN:
     def __init__(self, n_inputs, n_res=500, spectral_radius=0.9, alpha=0.3, seed=42):
         rng = np.random.default_rng(seed)
@@ -14,19 +15,25 @@ class ESN:
     def fit(self, U, Y, washout=100, reg=1e-6):
         N = U.shape[0]
         X = np.zeros((N, self.W.shape[0]))
-        for t in range(1,N):
-            X[t] = (1-self.alpha)*X[t-1] + self.alpha*np.tanh(self.Win @ U[t] + self.W @ X[t-1])
+        for t in range(1, N):
+            X[t] = (1 - self.alpha) * X[t - 1] + self.alpha * np.tanh(
+                self.Win @ U[t] + self.W @ X[t - 1]
+            )
         Xtr = X[washout:]
         Ytr = Y[washout:]
         # ridge
-        self.Wout = np.linalg.solve(Xtr.T @ Xtr + reg*np.eye(Xtr.shape[1]), Xtr.T @ Ytr)
+        self.Wout = np.linalg.solve(
+            Xtr.T @ Xtr + reg * np.eye(Xtr.shape[1]), Xtr.T @ Ytr
+        )
         return self
 
     def predict(self, U, x0=None):
         N = U.shape[0]
         X = np.zeros((N, self.W.shape[0])) if x0 is None else x0
         Yhat = np.zeros((N, self.Wout.shape[1]))
-        for t in range(1,N):
-            X[t] = (1-self.alpha)*X[t-1] + self.alpha*np.tanh(self.Win @ U[t] + self.W @ X[t-1])
+        for t in range(1, N):
+            X[t] = (1 - self.alpha) * X[t - 1] + self.alpha * np.tanh(
+                self.Win @ U[t] + self.W @ X[t - 1]
+            )
             Yhat[t] = X[t] @ self.Wout
         return Yhat

--- a/neural_chaos_lab_max/plotting.py
+++ b/neural_chaos_lab_max/plotting.py
@@ -1,8 +1,12 @@
 import plotly.graph_objects as go
-import numpy as np
+
 
 def plot_attractor(series, title="Attractor"):
-    x,y,z = series[:,0], series[:,1], series[:,2]
-    fig = go.Figure(data=[go.Scatter3d(x=x, y=y, z=z, mode='lines', line=dict(width=2))])
-    fig.update_layout(title=title, scene=dict(xaxis_title='x', yaxis_title='y', zaxis_title='z'))
+    x, y, z = series[:, 0], series[:, 1], series[:, 2]
+    fig = go.Figure(
+        data=[go.Scatter3d(x=x, y=y, z=z, mode="lines", line=dict(width=2))]
+    )
+    fig.update_layout(
+        title=title, scene=dict(xaxis_title="x", yaxis_title="y", zaxis_title="z")
+    )
     return fig

--- a/neural_chaos_lab_max/service.py
+++ b/neural_chaos_lab_max/service.py
@@ -1,22 +1,26 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-import numpy as np, os
+import numpy as np
+import os
 from .systems import lorenz, rossler
 from .neural_ode import NeuralODEModel
 import torch
 
 app = FastAPI(title="Neural Chaos Lab Max")
 
+
 class GenReq(BaseModel):
     system: str = "lorenz"
     n: int = 5000
 
+
 @app.post("/generate")
 def generate(req: GenReq):
-    series = lorenz(req.n) if req.system=="lorenz" else rossler(req.n)
+    series = lorenz(req.n) if req.system == "lorenz" else rossler(req.n)
     os.makedirs("data", exist_ok=True)
     np.savetxt("data/series.csv", series, delimiter=",")
     return {"ok": True, "shape": [int(x) for x in series.shape]}
+
 
 @app.post("/forecast")
 def forecast(steps: int = 200):

--- a/neural_chaos_lab_max/systems.py
+++ b/neural_chaos_lab_max/systems.py
@@ -1,23 +1,33 @@
 import numpy as np
 
-def lorenz(n=5000, dt=0.01, sigma=10.0, rho=28.0, beta=8/3):
+
+def lorenz(n=5000, dt=0.01, sigma=10.0, rho=28.0, beta=8 / 3):
     x, y, z = 1.0, 1.0, 1.0
     xs, ys, zs = [], [], []
     for _ in range(n):
-        dx = sigma*(y-x)
-        dy = x*(rho - z) - y
-        dz = x*y - beta*z
-        x += dx*dt; y += dy*dt; z += dz*dt
-        xs.append(x); ys.append(y); zs.append(z)
-    return np.stack([xs,ys,zs], axis=1)
+        dx = sigma * (y - x)
+        dy = x * (rho - z) - y
+        dz = x * y - beta * z
+        x += dx * dt
+        y += dy * dt
+        z += dz * dt
+        xs.append(x)
+        ys.append(y)
+        zs.append(z)
+    return np.stack([xs, ys, zs], axis=1)
+
 
 def rossler(n=5000, dt=0.01, a=0.2, b=0.2, c=5.7):
     x, y, z = 1.0, 1.0, 1.0
     xs, ys, zs = [], [], []
     for _ in range(n):
         dx = -y - z
-        dy = x + a*y
-        dz = b + z*(x - c)
-        x += dx*dt; y += dy*dt; z += dz*dt
-        xs.append(x); ys.append(y); zs.append(z)
-    return np.stack([xs,ys,zs], axis=1)
+        dy = x + a * y
+        dz = b + z * (x - c)
+        x += dx * dt
+        y += dy * dt
+        z += dz * dt
+        xs.append(x)
+        ys.append(y)
+        zs.append(z)
+    return np.stack([xs, ys, zs], axis=1)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,13 +1,13 @@
-import streamlit as st, numpy as np, os
+import streamlit as st
 from neural_chaos_lab_max.systems import lorenz, rossler
 from neural_chaos_lab_max.plotting import plot_attractor
 
 st.set_page_config(page_title="Neural Chaos Lab Max", layout="wide")
 st.title("Neural Chaos Lab Max")
 
-system = st.selectbox("System", ["lorenz","rossler"])
+system = st.selectbox("System", ["lorenz", "rossler"])
 n = st.slider("n", 1000, 10000, 5000, 500)
 if st.button("Generate"):
-    series = lorenz(n) if system=="lorenz" else rossler(n)
+    series = lorenz(n) if system == "lorenz" else rossler(n)
     fig = plot_attractor(series, f"{system} ({n})")
     st.plotly_chart(fig, use_container_width=True)


### PR DESCRIPTION
Automated cleanups: autoflake, isort, ruff --fix, black. Removes unused imports, splits semicolon statements, fixes whitespace/blank-lines. Should make CI green.